### PR TITLE
Add code for subcommands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.scripts]
-calc-pr = "metfish.commands:get_Pr_cli"
+metfish = "metfish:main"
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.

--- a/src/metfish/__init__.py
+++ b/src/metfish/__init__.py
@@ -1,0 +1,47 @@
+import numpy as np
+from importlib import import_module
+
+class Command:
+    def __init__(self, module, doc):
+        ar = f'metfish.{module}'.split('.')
+        self.pkg = '.'.join(ar[:-1])
+        self.func = ar[-1]
+        self.doc = doc
+
+    def get_func(self):
+        return getattr(import_module(self.pkg), self.func)
+
+
+def main():
+
+    # Add commands here
+    command_dict = {
+        'SAXS': {
+            'calc-pr': Command('calc_pr.main', 'Calculate P(r) curves for PDB structures'),
+        },
+    }
+    import sys
+    if len(sys.argv) == 1:
+        print('Usage: metfish <command> [options]')
+        print('Available commands are:\n')
+        for g, d in command_dict.items():
+            print(f' {g}')
+            for c, f in d.items():
+                nspaces = 16 - len(c)
+                desc = ''
+                print(f'    {c}' + ' '*nspaces + f.doc)
+            print()
+    else:
+        cmd = sys.argv[1]
+        for g, d in command_dict.items():
+            func = d.get(cmd)
+            if func is not None:
+                func = func.get_func()
+                break
+        if func is not None:
+            argv = sys.argv[2:]
+            sys.argv[0] = sys.argv[0] + " " + sys.argv[1]
+            func(argv)
+        else:
+            print("Unrecognized command: '%s'" % cmd, file=sys.stderr)
+

--- a/src/metfish/calc_pr.py
+++ b/src/metfish/calc_pr.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from .utils import get_Pr
 
-def get_Pr_cli(argv=None):
+def main(argv=None):
 
     desc = "Calculate an exact P(r) curve for a given structure"
     epi = """By default, Dmax is calculated from the max distance found in the structure."""
@@ -23,7 +23,7 @@ def get_Pr_cli(argv=None):
                         help="the path to write the file to. by default, write to stdout")
     parser.add_argument("-f", "--force", action='store_true', help="overwrite output if it exist", default=False)
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     out = sys.stdout
     if args.output is not None:
@@ -40,3 +40,6 @@ def get_Pr_cli(argv=None):
                   step=args.step)
 
     pd.DataFrame({"r": r, "P(r)": p}).to_csv(out, index=False)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Add place to register subcommands in top level __init__
- Update TOML to point to master command entry point
- Rename P(r) command functions

## Motivation

Since we are adding more scripts/commands for re-use, I restructured the package for organizing these commands as subcommands under one main command. 

## How to test the behavior?
After installing the `metfish` package, the `metfish` command should be available. Calling it with no arguments will reveal the subcommands.
```
$ metfish
Usage: metfish <command> [options]
Available commands are:

 SAXS
    calc-pr         Calculate P(r) curves for PDB structures
```

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [ ] Have you checked our [Contributing](https://github.com/exabiome/gtnet/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR clearly describes the problem and the solution?
- [ ] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/exabiome/gtnet/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
