### PR TITLE
Add variation figures from Jupyter notebook

### DIFF
--- a/src/metfish/analysis/visualizer.py
+++ b/src/metfish/analysis/visualizer.py
@@ -34,11 +34,11 @@ class ProteinVisualization:
         return palette
     
     def plot_all(self):
-        # self.plot_overall_metrics(['rmsd', 'lddt', 'saxs_kldiv'], 'overall_metrics.pdf')
-        # self.plot_model_improvement('model_improvement.pdf')
+        self.plot_overall_metrics(['rmsd', 'lddt', 'saxs_kldiv'], 'overall_metrics.pdf')
+        self.plot_model_improvement('model_improvement.pdf')
         self.plot_apo_holo_variation('apo_vs_holo_variation.pdf')
         self.plot_apo_holo_comparison('apo_vs_holo_model_comparison.pdf')
-        # self.plot_protein_summary_all()
+        self.plot_protein_summary_all()
     
     def plot_overall_metrics(self,
                             metrics: List[str],


### PR DESCRIPTION
## Motivation

Add plotting of variation of apo vs. holo pairs from the different models (previously in analysis Jupyter notebook).

## How to test the behavior?
```
python scripts/generate_figures.py
```

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [ ] Have you checked our [Contributing](https://github.com/exabiome/gtnet/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR clearly describes the problem and the solution?
- [ ] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/exabiome/gtnet/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
